### PR TITLE
Add state variable 'isPolyReady' + renameIdentity

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -17,9 +17,10 @@ import { keyExtractSuri, mnemonicGenerate, mnemonicValidate } from '@polkadot/ut
 import State from './State';
 import { createSubscription, unsubscribe } from './subscriptions';
 
-import { subscribeIdentifiedAccounts, subscribeNetwork, subscribeSelectedAccount } from '@polymath/extension/store/subscribers';
+import { subscribeAccountsCount, subscribeIdentifiedAccounts, subscribeNetwork, subscribeSelectedAccount } from '@polymath/extension/store/subscribers';
 import { setNetwork, setSelectedAccount } from '@polymath/extension/store/setters';
 import { callDetails } from '@polymath/extension/api';
+import { getAccountsCount } from '@polymath/extension/store/getters';
 
 type CachedUnlocks = Record<string, number>;
 
@@ -159,10 +160,15 @@ export default class Extension {
   private polyNetworkSubscribe (id: string, port: chrome.runtime.Port): boolean {
     const cb = createSubscription<'pri(polyNetwork.subscribe)'>(id, port);
 
-    const unsubscribe = subscribeNetwork(cb);
+    const reduxUnsub = subscribeNetwork((network) => {
+      cb(network);
+      reduxUnsub();
+      unsubscribe(id);
+    });
 
     port.onDisconnect.addListener((): void => {
-      unsubscribe();
+      reduxUnsub();
+      unsubscribe(id);
     });
 
     return true;
@@ -171,10 +177,36 @@ export default class Extension {
   private polySelectedAccountSubscribe (id: string, port: chrome.runtime.Port): boolean {
     const cb = createSubscription<'pri(polySelectedAccount.subscribe)'>(id, port);
 
-    const unsubscribe = subscribeSelectedAccount(cb);
+    const reduxUnsub = subscribeSelectedAccount((selected) => {
+      cb(selected);
+      unsubscribe(id);
+      reduxUnsub();
+    });
 
     port.onDisconnect.addListener((): void => {
-      unsubscribe();
+      reduxUnsub();
+      unsubscribe(id);
+    });
+
+    return true;
+  }
+
+  private polyIsReadySubscribe (id: string, port: chrome.runtime.Port): boolean {
+    const cb: (data: void) => void = createSubscription<'pri(polyIsReady.subscribe)'>(id, port);
+
+    // Store is ready once accounts count in Redux match the one of keyring.
+
+    const reduxUnsub = subscribeAccountsCount(() => {
+      if (Object.values(accountsObservable.subject.value).length === getAccountsCount()) {
+        unsubscribe(id);
+        reduxUnsub();
+        cb();
+      }
+    });
+
+    port.onDisconnect.addListener((): void => {
+      unsubscribe(id);
+      reduxUnsub();
     });
 
     return true;
@@ -519,28 +551,30 @@ export default class Extension {
       case 'pri(accounts.subscribe)':
         return this.accountsSubscribe(id, port);
 
-      // @TODO1 move to a separate request handler.
+        /** Polymesh endpoints  */
+
       case 'pri(polyAccounts.subscribe)':
         return this.polyAccountsSubscribe(id, port);
 
-      // @TODO1 move to a separate request handler.
       case 'pri(polyNetwork.subscribe)':
         return this.polyNetworkSubscribe(id, port);
 
-      // @TODO1 move to a separate request handler.
       case 'pri(polyNetwork.set)':
         return this.polyNetworkSet(request as RequestPolyNetworkSet);
 
-      // @TODO1 move to a separate request handler.
       case 'pri(polySelectedAccount.subscribe)':
         return this.polySelectedAccountSubscribe(id, port);
 
-      // @TODO1 move to a separate request handler.
       case 'pri(polySelectedAccount.set)':
         return this.polySelectedAccount(request as RequestPolySelectedAccountSet);
 
       case 'pri(polyCallDetails.get)':
         return this.polyCallDetailsGet(request as RequestPolyCallDetails);
+
+      case 'pri(polyIsReady.subscribe)':
+        return this.polyIsReadySubscribe(id, port);
+
+        /** End of Polymesh endpoints  */
 
       case 'pri(accounts.tie)':
         return this.accountsTie(request as RequestAccountTie);

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -79,7 +79,8 @@ export interface RequestSignatures {
   'pri(accounts.subscribe)': [RequestAccountSubscribe, boolean, AccountJson[]];
   'pri(polyAccounts.subscribe)': [RequestPolyAccountsSubscribe, boolean, IdentifiedAccount[]];
   'pri(polyNetwork.subscribe)': [RequestPolyNetworkSubscribe, boolean, NetworkName];
-  'pri(polySelectedAccount.subscribe)': [RequestPolySelectedAccountSubscribe, boolean, string | undefined]
+  'pri(polySelectedAccount.subscribe)': [RequestPolySelectedAccountSubscribe, boolean, string | undefined];
+  'pri(polyIsReady.subscribe)': [RequestPolyIsReadySubscribe, boolean, void]
   'pri(polyNetwork.set)': [RequestPolyNetworkSet, boolean];
   'pri(polySelectedAccount.set)': [RequestPolySelectedAccountSet, boolean];
   'pri(polyCallDetails.get)': [RequestPolyCallDetails, ResponsePolyCallDetails];
@@ -238,6 +239,8 @@ export type RequestPolyAccountsSubscribe = null;
 export type RequestPolyNetworkSubscribe = null;
 
 export type RequestPolySelectedAccountSubscribe = null;
+
+export type RequestPolyIsReadySubscribe = null;
 
 export interface RequestPolyNetworkSet {
   network: NetworkName

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -84,6 +84,7 @@ export interface RequestSignatures {
   'pri(polyNetwork.set)': [RequestPolyNetworkSet, boolean];
   'pri(polySelectedAccount.set)': [RequestPolySelectedAccountSet, boolean];
   'pri(polyCallDetails.get)': [RequestPolyCallDetails, ResponsePolyCallDetails];
+  'pri(polyIdentity.rename)': [RequestPolyIdentityRename, boolean];
   'pri(accounts.validate)': [RequestAccountValidate, boolean];
   'pri(accounts.changePassword)': [RequestAccountChangePassword, boolean];
   'pri(authorize.approve)': [RequestAuthorizeApprove, boolean];
@@ -252,6 +253,12 @@ export interface RequestPolySelectedAccountSet {
 
 export interface RequestPolyCallDetails {
   request: SignerPayloadJSON;
+}
+
+export interface RequestPolyIdentityRename {
+  network: NetworkName,
+  did: string,
+  name: string
 }
 
 export interface RequestRpcSend {

--- a/packages/extension-polymath-ui/src/Popup/index.tsx
+++ b/packages/extension-polymath-ui/src/Popup/index.tsx
@@ -13,7 +13,7 @@ import { setSS58Format } from '@polkadot/util-crypto';
 import { Loading } from '../components';
 import { AccountContext, ActionContext, AuthorizeReqContext, MediaContext, MetadataReqContext, SettingsContext, SigningReqContext } from '../components/contexts';
 import ToastProvider from '../components/Toast/ToastProvider';
-import { subscribeAccounts, subscribeAuthorizeRequests, subscribeMetadataRequests, subscribeSigningRequests } from '../messaging';
+import { subscribeAccounts, subscribeAuthorizeRequests, subscribeIsReady, subscribeMetadataRequests, subscribeSigningRequests } from '../messaging';
 import { buildHierarchy } from '../util/buildHierarchy';
 import Accounts from './Accounts';
 import Authorize from './Authorize';
@@ -68,6 +68,7 @@ export default function Popup (): React.ReactElement {
   const [signRequests, setSignRequests] = useState<null | SigningRequest[]>(null);
   const [isWelcomeDone, setWelcomeDone] = useState(false);
   const [settingsCtx, setSettingsCtx] = useState<SettingsStruct>(startSettings);
+  const [isPolyReady, setIsPolyReady] = useState<boolean>(false);
 
   const _onAction = (to?: string): void => {
     setWelcomeDone(window.localStorage.getItem('welcome_read') === 'ok');
@@ -82,7 +83,8 @@ export default function Popup (): React.ReactElement {
       subscribeAccounts(setAccounts),
       subscribeAuthorizeRequests(setAuthRequests),
       subscribeMetadataRequests(setMetaRequests),
-      subscribeSigningRequests(setSignRequests)
+      subscribeSigningRequests(setSignRequests),
+      subscribeIsReady(() => setIsPolyReady(true))
     ]).catch(console.error);
 
     uiSettings.on('change', (settings): void => {

--- a/packages/extension-polymath-ui/src/messaging.ts
+++ b/packages/extension-polymath-ui/src/messaging.ts
@@ -176,6 +176,10 @@ export async function subscribePolySelectedAccount (cb: (selected: string | unde
   return sendMessage('pri(polySelectedAccount.subscribe)', null, cb);
 }
 
+export async function subscribeIsReady (cb: () => void): Promise<boolean> {
+  return sendMessage('pri(polyIsReady.subscribe)', null, cb);
+}
+
 export async function setPolySelectedAccount (account: string): Promise<boolean> {
   return sendMessage('pri(polySelectedAccount.set)', { account });
 }

--- a/packages/extension-polymath-ui/src/messaging.ts
+++ b/packages/extension-polymath-ui/src/messaging.ts
@@ -14,6 +14,7 @@ import { metadataExpand } from '@polkadot/extension-chains';
 import chrome from '@polkadot/extension-inject/chrome';
 import { KeyringPair$Json } from '@polkadot/keyring/types';
 import { SignerPayloadJSON } from '@polkadot/types/types';
+import { NetworkName } from '@polymath/extension/types';
 
 interface Handler {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -182,6 +183,14 @@ export async function subscribeIsReady (cb: () => void): Promise<boolean> {
 
 export async function setPolySelectedAccount (account: string): Promise<boolean> {
   return sendMessage('pri(polySelectedAccount.set)', { account });
+}
+
+export async function setPolyNetwork (network: NetworkName): Promise<boolean> {
+  return sendMessage('pri(polyNetwork.set)', { network });
+}
+
+export async function renameIdentity (network: NetworkName, did: string, name: string): Promise<boolean> {
+  return sendMessage('pri(polyIdentity.rename)', { network, did, name });
 }
 
 export async function getPolyCallDetails (request: SignerPayloadJSON): Promise<ResponsePolyCallDetails> {

--- a/packages/extension-polymath/src/store/features/identities.ts
+++ b/packages/extension-polymath/src/store/features/identities.ts
@@ -12,6 +12,7 @@ const initialState: State = {
 
 type SetIdentityPayload = { network: NetworkName, data: IdentityData };
 type RemoveIdentityPayload = { network: NetworkName, did: string };
+type RenameIdentityPayload = { network: NetworkName, did: string, name: string };
 
 const identitiesSlice = createSlice({
   name: 'identities',
@@ -29,6 +30,11 @@ const identitiesSlice = createSlice({
       const { did, network } = action.payload;
 
       delete state[network][did];
+    },
+    renameIdentity (state, action: PayloadAction<RenameIdentityPayload>) {
+      const { did, name, network } = action.payload;
+
+      state[network][did].alias = name;
     }
   }
 });

--- a/packages/extension-polymath/src/store/getters.ts
+++ b/packages/extension-polymath/src/store/getters.ts
@@ -1,4 +1,4 @@
-import { network, networkUrl, selectedAccount } from './selectors';
+import { accountsCount, network, networkUrl, selectedAccount } from './selectors';
 
 import store from '.';
 import { NetworkName } from '../types';
@@ -15,8 +15,13 @@ function getSelectedAccount (): string | undefined {
   return selectedAccount(store.getState());
 }
 
+function getAccountsCount (): number {
+  return accountsCount(store.getState());
+}
+
 export {
   getNetwork,
   getNetworkUrl,
-  getSelectedAccount
+  getSelectedAccount,
+  getAccountsCount
 };

--- a/packages/extension-polymath/src/store/index.ts
+++ b/packages/extension-polymath/src/store/index.ts
@@ -38,7 +38,7 @@ if (process.env.NODE_ENV === 'development' && (module as any).hot) {
   });
 }
 
-export type AppDispatch = typeof store.dispatch
+export type Dispatch = typeof store.dispatch
 
 export const persister = persistStore(store);
 

--- a/packages/extension-polymath/src/store/selectors.ts
+++ b/packages/extension-polymath/src/store/selectors.ts
@@ -44,6 +44,11 @@ export const accounts = createSelector(
   (network, accounts) => accounts[network]
 );
 
+export const accountsCount = createSelector(
+  accounts,
+  (accounts): number => Object.values(accounts).length
+);
+
 export const identifiedAccounts = createSelector(
   accounts,
   reversedDidList,

--- a/packages/extension-polymath/src/store/setters.ts
+++ b/packages/extension-polymath/src/store/setters.ts
@@ -2,6 +2,7 @@ import store from '.';
 import { NetworkName } from '../types';
 import { actions as networkActions } from './features/network';
 import { actions as accountActions } from './features/accounts';
+import { actions as identityActions } from './features/identities';
 
 function setNetwork (network: NetworkName): void {
   store.dispatch(networkActions.setNetwork(network));
@@ -11,7 +12,12 @@ function setSelectedAccount (account: string): void {
   store.dispatch(accountActions.selectAccount(account));
 }
 
+function renameIdentity (network: NetworkName, did: string, name: string) {
+  store.dispatch(identityActions.renameIdentity({ network, did, name }));
+}
+
 export {
   setNetwork,
-  setSelectedAccount
+  setSelectedAccount,
+  renameIdentity
 };

--- a/packages/extension-polymath/src/store/subscribers.ts
+++ b/packages/extension-polymath/src/store/subscribers.ts
@@ -1,7 +1,7 @@
 import { Unsubscribe } from '@reduxjs/toolkit';
 import { IdentifiedAccount, NetworkName } from '../types';
 import reduxSubscribe from './reduxSubscribe';
-import { didsList, identifiedAccounts, network, selectedAccount } from './selectors';
+import { accountsCount, didsList, identifiedAccounts, network, selectedAccount } from './selectors';
 
 export function subscribeDidsList (cb: (dids: string[]) => void): Unsubscribe {
   return reduxSubscribe(didsList, cb);
@@ -17,4 +17,8 @@ export function subscribeNetwork (cb: (network: NetworkName) => void): Unsubscri
 
 export function subscribeSelectedAccount (cb: (selected: string | undefined) => void): Unsubscribe {
   return reduxSubscribe(selectedAccount, cb);
+}
+
+export function subscribeAccountsCount (cb: (count: number) => void): Unsubscribe {
+  return reduxSubscribe(accountsCount, cb);
 }

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -10,9 +10,8 @@ import { AccountsStore } from '@polkadot/extension-base/stores';
 import chrome from '@polkadot/extension-inject/chrome';
 import keyring from '@polkadot/ui-keyring';
 import { assert } from '@polkadot/util';
-
 import { cryptoWaitReady } from '@polkadot/util-crypto';
-import { meshAccountsEnhancer } from '@polymath/extension';
+import initPolymesh from '@polymath/extension';
 // setup the notification (same a FF default background, white text)
 chrome.browserAction.setBadgeBackgroundColor({ color: '#d90000' });
 
@@ -34,7 +33,7 @@ cryptoWaitReady()
     // load all the keyring data
     keyring.loadAll({ store: new AccountsStore(), type: 'sr25519' });
 
-    meshAccountsEnhancer();
+    initPolymesh();
 
     console.log('initialization completed');
   })


### PR DESCRIPTION
This PR brings two new endpoints:
- `subscribeIsReady(cb)` which notifies the frontend once the backend is ready.
- `renameIdentity` which could be used to rename an identity.